### PR TITLE
HOCS-1076 Use cert-manager.io

### DIFF
--- a/kd/ingress.yaml
+++ b/kd/ingress.yaml
@@ -3,17 +3,17 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    cert-manager.io/enabled: "true"
     ingress.kubernetes.io/secure-backends: "true"
     ingress.kubernetes.io/backend-protocol: "HTTPS"
     ingress.kubernetes.io/proxy-body-size: "52m"
     kubernetes.io/ingress.class: nginx-external
-    stable.k8s.psg.io/kcm.provider: http
     ingress.kubernetes.io/proxy-buffer-size: 128k
     ingress.kubernetes.io/server-snippets: |
       client_header_buffer_size     8k;
       large_client_header_buffers   4 128k;
   labels:
-    stable.k8s.psg.io/kcm.class: default
+    cert-manager.io/solver: http01
   name: hocs-frontend
 spec:
   rules:
@@ -32,4 +32,4 @@ spec:
   tls:
   - hosts:
     - {{.DOMAIN_NAME}}
-    secretName: hocs-frontend-external-tls
+    secretName: hocs-frontend-external-tls-cert


### PR DESCRIPTION
The Kubernetes configuration prior to this commit used kube-cert-manager
to manage certificates from Let's Encrypt. However, kube-cert-manager is
being deprecated upstream and will cease working in June 2020.

This commit updates the configuration to use Jetstack's cert-manager,
which is now deployed on the ACP clusters.

The TLS keypair is stored in a secret. We rename the secret here to
ensure that the certificate isn't managed by both kube-cert-manager and
cert-manager at the same time -- this isn't an issue in development, but
in production could go wrong, so this commit creates a new secret for
the newly managed certificate. After this change has been deployed to an
environment and the CSR resolved, the old certificate can be deleted.