### PR TITLE
Add internal ingress

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -61,7 +61,7 @@ elif [[ "${KUBE_NAMESPACE}" == "cs-prod" ]] ; then
     export DNS_PREFIX=www.cs
     export KC_REALM=https://sso.digital.homeoffice.gov.uk/auth/realms/hocs-prod
 elif [[ "${KUBE_NAMESPACE}" == "cs-dev" ]] ; then
-    export DNS_PREFIX=dev.cs-notprod
+    export DNS_PREFIX=dev.internal.cs-notprod
     export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
 elif [[ "${KUBE_NAMESPACE}" == "wcs-dev" ]] ; then
     export DNS_PREFIX=dev.wcs-notprod
@@ -79,24 +79,31 @@ elif [[ "${KUBE_NAMESPACE}" == "wcs-demo" ]] ; then
     export DNS_PREFIX=demo.wcs-notprod
     export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
 else
-    export DNS_PREFIX=${DOMAIN}.${DOMAIN}-notprod
+    export DNS_PREFIX=${ENVIRONMENT}.${DOMAIN}-notprod
     export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
 fi
 
-export DOMAIN_NAME=${DNS_PREFIX}.homeoffice.gov.uk
+export DOMAIN_SUFFIX=.homeoffice.gov.uk
+export DOMAIN_NAME=${DNS_PREFIX}${DNS_SUFFIX}
+
+if [[ $DOMAIN_PREFIX == *"internal"* ]]; then
+  export INGRESS_TYPE="internal"
+else
+  export INGRESS_TYPE="external"
+fi
 
 echo
 echo "Deploying hocs-frontend to ${ENVIRONMENT}"
 echo "Keycloak realm: ${KC_REALM}"
 echo "Keycloak domain: ${KC_DOMAIN}"
-echo "domain name: ${DOMAIN_NAME}"
+echo "${INGRESS_TYPE} domain: ${DOMAIN_NAME}"
 echo
 
 cd kd
 
 kd --insecure-skip-tls-verify \
    --timeout 10m \
-    -f ingress.yaml \
+    -f ingress-${INGRESS_TYPE}.yaml \
     -f converter-configmap.yaml \
     -f configmap.yaml \
     -f deployment.yaml \

--- a/kd/ingress-external.yaml
+++ b/kd/ingress-external.yaml
@@ -2,6 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  # remember to make any changes to the internal ingress as well if appropriate
   annotations:
     cert-manager.io/enabled: "true"
     ingress.kubernetes.io/secure-backends: "true"

--- a/kd/ingress-internal.yaml
+++ b/kd/ingress-internal.yaml
@@ -1,0 +1,39 @@
+# Kubernetes lets you have both an internal and external ingress.
+# However, keycloak-gatekeeper does not support multiple URLs, so
+#   neither do we.
+# Check ../deploy.sh to see which gets deployed for a particular environment.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/enabled: "true"
+    ingress.kubernetes.io/secure-backends: "true"
+    ingress.kubernetes.io/backend-protocol: "HTTPS"
+    ingress.kubernetes.io/proxy-body-size: "52m"
+    kubernetes.io/ingress.class: nginx-internal
+    ingress.kubernetes.io/proxy-buffer-size: 128k
+    ingress.kubernetes.io/server-snippets: |
+      client_header_buffer_size     8k;
+      large_client_header_buffers   4 128k;
+  name: hocs-frontend-internal
+  labels:
+    # internal ingresses can't use http01 as Let's Encrypt can't see it
+    cert-manager.io/solver: route53
+spec:
+  rules:
+  - host: {{.DOMAIN_NAME}}
+    http:
+      paths:
+      - backend:
+          serviceName: hocs-frontend
+          servicePort: 443
+        path: /
+      - backend:
+          serviceName: hocs-audit
+          servicePort: 443
+        path: /export
+
+  tls:
+  - hosts:
+    - {{.DOMAIN_NAME}}
+    secretName: hocs-frontend-internal-tls-cert


### PR DESCRIPTION
This commit adds an internal ingress to supplement the external
ingresses that already exist, and makes the cs-dev environment use the
internal ingress instead of the external one. You can choose either
ingress for any given environment, by modifying its entry in the
deploy.sh script -- although you cannot have both.

Currently, you can only use an external ingress if your IP address is
in the allowed list of IP addresses. This, in practice, is office
locations and does not include devices working elsewhere, such as from
home.

This meant that people wishing to access the application from a
non-standard location needed to rely on workarounds. The ACP "Tunnel
All" VPN is often used for this purpose, which routes all traffic from a
device over an ACP AWS VPC (that is, our hosting provider's network),
and has a side-effect of changing the apparent IP address to one
permissible by the IP allowlist. This wasn't efficient -- especially
apparent when one tries to log into the system whilst simultaneously
using video conferencing.

We can fix this by exposing an internal VPN-accessible ingress as an
optional replacement for our our existing Internet-addressable external
ingress, making it much easier for developers to access the service from
any location, with the downside of making it more complex for "normal"
users on corporate hardware.

Environments using the internal ingress instead of the external one will
no longer be accessible via the Internet, and therefore will not be
available via Poise by default. Anybody wanting to connect must access
the service via the "kube-platform" ACP VPN. Most users of the
non-production environments are connecting to the kube-platform VPN
routinely anyway: most of the development toolset, such as Drone CI's
web frontend and log aggregation frontend Kibana, are already using
internal ingresses.

Kubernetes allows you to have lots of ingresses, but our app doesn't
support it. Specifically, the redirection URL setting of Keycloak
Gatekeeper can only be set once, so although you can authenticate from
an arbitrary hostname, it is difficult (or at least, annoying) to return
to the app after being dealt with by the central Keycloak server.

Theoretically we could spin up a second hocs-frontend pod with a
different redirection URL set, but at the moment that introduces more
complexity than an additional ingress is worth.

We decide which ingress to deploy based on the hostname: if the DNS prefix
contains "internal", we use the internal configuration instead of the
external one.

The two ingress configurations are broadly similar. The main difference,
other than the labels used to tell ACP which type we want, is the way we
obtain certificates from Let's Encrypt. Normally Let's Encrypt (our TLS
certificate provider) uses a HTTP request to validate that the person
requesting a certificate actually controls the associated hostname.
That's not possible with an internal ingress, as it's not routed over
the Internet. Instead, we tell it to confirm via the Domain Name System.

This commit only changes the behaviour for the cs-dev environment for
now. Subsequent environments will be introduced in subsequent commits.