### PR TITLE
Hocs 1859

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 Contains config maps for the docs-converter and the frontend. And the deployment script for the frontend.
 
 The associated network policies are instead stored in [UKHomeOffice/kube-hocs](https://github.com/ukhomeoffice/kube-hocs).
+
+If you change the ingress hostname, ensure you also add it as an acceptable
+redirect URI in the appropriate client configuration in the relevant Keycloak
+security admin console.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # kube-hocs-frontend
 Contains config maps for the docs-converter and the frontend. And the deployment script for the frontend.
+
+The associated network policies are instead stored in [UKHomeOffice/kube-hocs](https://github.com/ukhomeoffice/kube-hocs).

--- a/deploy.sh
+++ b/deploy.sh
@@ -64,13 +64,13 @@ elif [[ "${KUBE_NAMESPACE}" == "cs-dev" ]] ; then
     export DNS_PREFIX=dev.internal.cs-notprod
     export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
 elif [[ "${KUBE_NAMESPACE}" == "wcs-dev" ]] ; then
-    export DNS_PREFIX=dev.wcs-notprod
+    export DNS_PREFIX=dev.internal.wcs-notprod
     export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
 elif [[ "${KUBE_NAMESPACE}" == "cs-qa" ]] ; then
     export DNS_PREFIX=qa.cs-notprod
     export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
 elif [[ "${KUBE_NAMESPACE}" == "wcs-qa" ]] ; then
-    export DNS_PREFIX=qa.wcs-notprod
+    export DNS_PREFIX=qa.internal.wcs-notprod
     export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
 elif [[ "${KUBE_NAMESPACE}" == "cs-demo" ]] ; then
     export DNS_PREFIX=demo.cs-notprod


### PR DESCRIPTION
In tandem with this change you will need to ensure:
* redirect URIs in Keycloak are updated to reflect the new URLs
* appropriate network policies are in effect to permit deployments with the `hocs-frontend` role to communicate with the internal ingress

You can deploy this change to dev by restarting the latest `hocs-frontend` build.
Changes to the qa environment should be made via a manual deployment in the usual manner.