### PR TITLE
Double RAM limit for hocs-frontend container

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -308,7 +308,7 @@ spec:
         resources:
           limits:
             cpu: 900m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 200m
             memory: 80Mi


### PR DESCRIPTION
In our QA environment the hocs-frontend container in the hocs-frontend
pod gets killed for using too much memory:

    lastState:
      terminated:
        containerID: docker://81ef7354e094cf5cf4828ce58f6e1bcc6f1da9badc5574015142935dda59a5bf
        exitCode: 0
        finishedAt: "2020-09-18T10:28:17Z"
        reason: OOMKilled
        startedAt: "2020-09-18T10:25:53Z"

This commit doubles the threshold where the OOM killer kicks in, from 0.25 GiB
to 0.5 GiB. As a reminder, the "limit" field is the absolute maximum the
container is permitted to use, whereas the "request" field is the absolute
minimum the container needs to start. Kubernetes will dynamically allocate
RAM within those two values as it deems appropriate.