### PR TITLE
HOCS-1865 Add env var for accessibility statement

### DIFF
--- a/kd/configmap.yaml
+++ b/kd/configmap.yaml
@@ -4,3 +4,4 @@ metadata:
   name: hocs-frontend
 data:
   clientside: 'true'
+  a11y-url: 'https://horizon.homeoffice.gov.uk/page/accessibility-statement-internal-home-office-systems-0'

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -230,6 +230,11 @@ spec:
               configMapKeyRef:
                 name: hocs-frontend
                 key: clientside
+          - name: ACCESSIBILITY_STATEMENT_URL
+            valueFrom:
+              configMapKeyRef:
+                name: hocs-frontend
+                key: a11y-url
           - name: MAX_UPLOAD_SIZE
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
This commit adds the environment variable introduced in
https://github.com/UKHomeOffice/hocs-frontend/pull/516.

We define the environment variable's contents in the hocs-frontend
configmap, and set the default value to the interim accessibility
statement published by the Home Office on its intranet.