### PR TITLE
HOCS-1930-Msg-Document-Support

### DIFF
--- a/kd/converter-configmap.yaml
+++ b/kd/converter-configmap.yaml
@@ -5,4 +5,4 @@ metadata:
 data:
   converter_timeout: '300000'
   max_filesize: '52428800'
-  supported_types: 'doc,docx,txt,rtf,html,pdf,jpg,jpeg,tif,tiff,png,bmp,gif,xls,xlsx'
+  supported_types: 'doc,docx,txt,rtf,html,pdf,jpg,jpeg,tif,tiff,png,bmp,gif,xls,xlsx,msg'


### PR DESCRIPTION
Whitelisted MSG files as case document uploads.