### PR TITLE
Add basic linting Drone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,58 @@
+---
+
+kind: pipeline
+type: kubernetes
+name: lint
+
+steps:
+- name: lint bash
+  image: koalaman/shellcheck-alpine
+  commands:
+    - shellcheck *.sh
+  depends_on:
+    - clone
+
+---
+
+kind: pipeline
+type: kubernetes
+name: dry-run
+
+# This pipeline runs deploy.sh with a few different ENVIRONMENTs set
+# we run them with DRY_RUN=true so they don't do anything
+#
+# We're essentially checking that deploy.sh finishes with an exit code
+# of zero, which will only happen if all accessed environment variables
+# are defined correctly
+#
+# This Drone pipeline doesn't have access to actual kube tokens so there's
+# no danger of actually deploying anywhere
+
+steps:
+- name: dry-run kd dev
+  image: quay.io/ukhomeofficedigital/kd:v1.16.0
+  environment:
+    DRY_RUN: true
+    VERSION: test
+    ENVIRONMENT: wcs-dev
+    KUBE_TOKEN: test
+    POISE_WHITELIST: "127.0.0.1/32"
+  commands:
+    - bash -x deploy.sh
+  depends_on:
+    - clone
+
+- name: dry-run kd prod
+  image: quay.io/ukhomeofficedigital/kd:v1.16.0
+  environment:
+    DRY_RUN: true
+    VERSION: test
+    ENVIRONMENT: cs-prod
+    KUBE_TOKEN: test
+    POISE_WHITELIST: "127.0.0.1/32"
+  commands:
+    - bash -x deploy.sh
+  depends_on:
+    - clone
+
+...

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ export KUBE_TOKEN=${KUBE_TOKEN}
 export VERSION=${VERSION}
   
 export DOMAIN="cs"
-if [ ${KUBE_NAMESPACE%-*} == "wcs" ]; then
+if [ "${KUBE_NAMESPACE%-*}" == "wcs" ]; then
     export DOMAIN="wcs"
 fi
 


### PR DESCRIPTION
While trying to do something fairly complex with the Bash scripting in
this repo, I found myself missing the ability to run tests.

This commit adds some incredibly basic "tests": it runs deploy.sh with a
few different options to check they all work. Successfully reaching the
end of the deploy.sh script is deemed good enough to greenlight the
build; most common errors will be caught by either kd or bash and cause
a non-zero exit code.

For example:
- bad templates that do not apply
- bad syntax in Bash
- environment variables referenced without being set

Bash is notoriously lax at syntax, so I added a Bash linter as well.
It's one I've used locally for a while, and mainly highlights beginner
and intermediate level syntax errors, where the shell would otherwise do
strange or cryptic behaviour.