### PR TITLE
HOCS-2729 Allow multiple ingresses

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -11,61 +11,52 @@ if [ "${KUBE_NAMESPACE%-*}" == "wcs" ]; then
     export DOMAIN="wcs"
 fi
 
+export SUBNAMESPACE="${KUBE_NAMESPACE#*-}" # e.g. dev, qa
+
 if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
     export MIN_REPLICAS="2"
     export MAX_REPLICAS="6"
     export KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
+  if [[ "${KUBE_NAMESPACE}" == "wcs-prod" ]] ; then
+      export DOMAIN_NAME="www.cs.homeoffice.gov.uk"
+      export INTERNAL_DOMAIN_NAME=false
+      export KC_REALM=https://sso.digital.homeoffice.gov.uk/auth/realms/HOCS
+  elif [[ "${KUBE_NAMESPACE}" == "cs-prod" ]] ; then
+      export DOMAIN_NAME="www.wcs.homeoffice.gov.uk"
+      export INTERNAL_DOMAIN_NAME=false
+      export KC_REALM=https://sso.digital.homeoffice.gov.uk/auth/realms/hocs-prod
+  fi
 else
+    # non-production defaults:
     export MIN_REPLICAS="1"
     export MAX_REPLICAS="2"
     export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod  
     export KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-fi
 
-if [[ "${KUBE_NAMESPACE}" == "wcs-prod" ]] ; then
-    export DNS_PREFIX=www.wcs
-    export KC_REALM=https://sso.digital.homeoffice.gov.uk/auth/realms/HOCS
-elif [[ "${KUBE_NAMESPACE}" == "cs-prod" ]] ; then
-    export DNS_PREFIX=www.cs
-    export KC_REALM=https://sso.digital.homeoffice.gov.uk/auth/realms/hocs-prod
-elif [[ "${KUBE_NAMESPACE}" == "cs-dev" ]] ; then
-    export DNS_PREFIX=dev.internal.cs-notprod
-elif [[ "${KUBE_NAMESPACE}" == "wcs-dev" ]] ; then
-    export DNS_PREFIX=dev.internal.wcs-notprod
-elif [[ "${KUBE_NAMESPACE}" == "cs-qa" ]] ; then
-    export DNS_PREFIX=qa.internal.cs-notprod
-elif [[ "${KUBE_NAMESPACE}" == "wcs-qa" ]] ; then
-    export DNS_PREFIX=qa.internal.wcs-notprod
-elif [[ "${KUBE_NAMESPACE}" == "cs-demo" ]] ; then
-    export DNS_PREFIX=demo.cs-notprod
-elif [[ "${KUBE_NAMESPACE}" == "wcs-demo" ]] ; then
-    export DNS_PREFIX=demo.wcs-notprod
-elif [[ "${KUBE_NAMESPACE}" == "hocs-qax" ]] ; then
-    export DNS_PREFIX=qax.internal.cs-notprod
-else
-    export DNS_PREFIX=${ENVIRONMENT}.internal.${DOMAIN}-notprod
-fi
+    export DOMAIN_NAME="${SUBNAMESPACE}.${DOMAIN}-notprod.homeoffice.gov.uk"
+    export INTERNAL_DOMAIN_NAME="${SUBNAMESPACE}.internal.${DOMAIN}.homeoffice.gov.uk"
 
-export DNS_SUFFIX=.homeoffice.gov.uk
-export DOMAIN_NAME=${DNS_PREFIX}${DNS_SUFFIX}
-
-export INGRESS_TYPE="external"
-if [[ $DNS_PREFIX == *"internal"* ]]; then
-  export INGRESS_TYPE="internal"
+    # but remove the ingress for demo (preprod)
+    # so at least one non-prod namespace has prod-like keycloak-proxy settings
+    if [[ ${KUBE_NAMESPACE} == *demo ]]; then
+      export INTERNAL_DOMAIN_NAME=false
+    fi
 fi
 
 echo
 echo "Deploying hocs-frontend to ${ENVIRONMENT}"
 echo "Keycloak realm: ${KC_REALM}"
-echo "${INGRESS_TYPE} domain: ${DOMAIN_NAME}"
+echo "External domain: ${DOMAIN_NAME}"
+echo "Internal domain: ${INTERNAL_DOMAIN_NAME:-not set}"
 echo
 
 cd kd
 
 kd --insecure-skip-tls-verify \
    --timeout 10m \
-    -f ingress-${INGRESS_TYPE}.yaml \
+    -f ingress-internal.yaml \
+    -f ingress-external.yaml \
     -f converter-configmap.yaml \
     -f configmap.yaml \
     -f deployment.yaml \

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@ export IP_WHITELIST=${POISE_WHITELIST}
 export KUBE_NAMESPACE=${ENVIRONMENT}
 export KUBE_TOKEN=${KUBE_TOKEN}
 export VERSION=${VERSION}
-  
+
 export DOMAIN="cs"
 if [ "${KUBE_NAMESPACE%-*}" == "wcs" ]; then
     export DOMAIN="wcs"
@@ -13,8 +13,7 @@ fi
 
 export SUBNAMESPACE="${KUBE_NAMESPACE#*-}" # e.g. dev, qa
 
-if [[ ${KUBE_NAMESPACE} == *prod ]]
-then
+if [[ ${KUBE_NAMESPACE} == *prod ]]; then
     export MIN_REPLICAS="2"
     export MAX_REPLICAS="6"
     export KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
@@ -31,7 +30,7 @@ else
     # non-production defaults:
     export MIN_REPLICAS="1"
     export MAX_REPLICAS="2"
-    export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod  
+    export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
     export KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
 
     export DOMAIN_NAME="${SUBNAMESPACE}.${DOMAIN}-notprod.homeoffice.gov.uk"

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -138,7 +138,6 @@ spec:
           - --server-read-timeout=60s
           - --server-write-timeout=60s
           - --no-redirects=false
-          - --redirection-url=https://{{.DOMAIN_NAME}}
           - --resources=uri=/health|white-listed=true
           - --resources=uri=/public/*|white-listed=true
           - --resources=uri=/*
@@ -148,7 +147,12 @@ spec:
           - --enable-logout-redirect=true
           - --enable-refresh-tokens=true
           - --encryption-key=$(ENCRYPTION_KEY)
+            {{ if not .INTERNAL_DOMAIN_NAME }}
+            # in production there's only one ingress
+            # which means we can hardcode things for security:
+          - --redirection-url=https://{{.DOMAIN_NAME}}
           - --cookie-domain={{.DOMAIN_NAME}}
+            {{ end }}
         ports:
           - name: keycloak-http
             containerPort: 8081
@@ -189,7 +193,6 @@ spec:
           - --server-read-timeout=60s
           - --server-write-timeout=60s
           - --no-redirects=true
-          - --redirection-url=https://{{.DOMAIN_NAME}}
           - --resources=uri=/health|white-listed=true
           - --resources=uri=/public/*|white-listed=true
           - --resources=uri=/*
@@ -197,7 +200,12 @@ spec:
           - --http-only-cookie=true
           - --enable-refresh-tokens=true
           - --encryption-key=$(ENCRYPTION_KEY)
+            {{ if not .INTERNAL_DOMAIN_NAME }}
+            # in production there's only one ingress
+            # which means we can hardcode things for security:
+          - --redirection-url=https://{{.DOMAIN_NAME}}
           - --cookie-domain={{.DOMAIN_NAME}}
+            {{ end }}
         ports:
           - name: keycloak-http
             containerPort: 8082

--- a/kd/ingress-internal.yaml
+++ b/kd/ingress-internal.yaml
@@ -1,7 +1,5 @@
-# Kubernetes lets you have both an internal and external ingress.
-# However, keycloak-gatekeeper does not support multiple URLs, so
-#   neither do we.
-# Check ../deploy.sh to see which gets deployed for a particular environment.
+---
+{{ if .INTERNAL_DOMAIN_NAME }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +19,7 @@ metadata:
     cert-manager.io/solver: route53
 spec:
   rules:
-  - host: {{.DOMAIN_NAME}}
+  - host: {{.INTERNAL_DOMAIN_NAME}}
     http:
       paths:
       - backend:
@@ -35,5 +33,6 @@ spec:
 
   tls:
   - hosts:
-    - {{.DOMAIN_NAME}}
+    - {{.INTERNAL_DOMAIN_NAME}}
     secretName: hocs-frontend-internal-tls-cert
+{{ end }}


### PR DESCRIPTION
This commit removes the hard-coded redirection URL from the
keycloak-gatekeeper (keycloak-proxy) configurations for non-production
environments. This means keycloak-gatekeeper will try and guess the
correct values from the host header. That way we can use multiple
ingresses.

This makes it slightly less secure, so we don't do it for production. As
we don't do it for production, we also don't do it for demo -- so we
have at least one non-production environment in our pipeline with
similar settings to notice any (unlikely) problems.

Due to limitations with how the host header works, this commit breaks
the logout link on most environments, as Keycloak tries to redirect to
http://{endpoint} not https://{endpoint} which we've disallowed in our
Keycloak realm configuration.

----

This commit also tidies the deploy.sh script a bit.
Instead of a long if/else tower which requires updates every time
there's a new namespace, we take apart the xxx-yyy format of the k8s
namespace name and build the ingress hostnames programatically. Anything
that isn't "wcs" will default to "cs". I considered making them match
the namespace name precisely, but I think that just exposes underlying
infrastructure topology that nobody should need to care about.

This will mean that environments using the cleanup "final else" will
change URL as a result of this change. For example, hocs-delta will now
be at delta.internal, instead of hocs-delta.internal.

----

A second commit does some minor formatting fixes.