### PR TITLE
HOCS-1711 Add Poise whitelisting on ingresses

### DIFF
--- a/kd/ingress-external.yaml
+++ b/kd/ingress-external.yaml
@@ -10,6 +10,7 @@ metadata:
     ingress.kubernetes.io/proxy-body-size: "52m"
     kubernetes.io/ingress.class: nginx-external
     ingress.kubernetes.io/proxy-buffer-size: 128k
+    ingress.kubernetes.io/whitelist-source-range: {{.IP_WHITELIST}}
     ingress.kubernetes.io/server-snippets: |
       client_header_buffer_size     8k;
       large_client_header_buffers   4 128k;


### PR DESCRIPTION
We pass through an IP_WHITELIST environment variable to the templater,
but for unknown reasons the code that used it was removed in commit
ec5ce52f0ad252609bcd77b899732450b76f156f.

This commit re-adds them so that the whitelist is defined centrally in
Drone again.

** This will overwrite the existing Poise whitelist in production on
next deploy. **