### PR TITLE
Fix bad templating on cs-demo ingress

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -39,7 +39,7 @@ else
     # but remove the ingress for demo (preprod)
     # so at least one non-prod namespace has prod-like keycloak-proxy settings
     if [[ ${KUBE_NAMESPACE} == *demo ]]; then
-      export INTERNAL_DOMAIN_NAME=false
+      export INTERNAL_DOMAIN_NAME=''
     fi
 fi
 


### PR DESCRIPTION
`false` was resolving as truthy for the Go templating, meaning that
instead of simply not applying the internal ingress we were instead
applying a malformed one, which was causing kd to fail.

This commit switches `false` to `''`, which actually resolves to falsey,
instead of being a string with the word "false" written inside.