### PR TITLE
Opt out of internal ingress in script not template

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -54,7 +54,7 @@ cd kd
 
 kd --insecure-skip-tls-verify \
    --timeout 10m \
-    -f ingress-internal.yaml \
+    ${INTERNAL_DOMAIN_NAME:+ -f ingress-internal.yaml} \
     -f ingress-external.yaml \
     -f converter-configmap.yaml \
     -f configmap.yaml \

--- a/kd/ingress-internal.yaml
+++ b/kd/ingress-internal.yaml
@@ -1,5 +1,4 @@
 ---
-{{ if .INTERNAL_DOMAIN_NAME }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -35,4 +34,3 @@ spec:
   - hosts:
     - {{.INTERNAL_DOMAIN_NAME}}
     secretName: hocs-frontend-internal-tls-cert
-{{ end }}


### PR DESCRIPTION
kubectl can't cope with empty objects being passed to it, so our
previous way of not deploying an internal ingress to demo or prod
doesn't work, so instead of using templating tricks we do it in Bash
instead.

This uses a slightly cursed ${VAR:+foo} parameter expansion which only
outputs foo if $VAR is empty.

Upstream bug: https://github.com/UKHomeOffice/kd/issues/128