### PR TITLE
HOCS-2239: add downscaler annotation

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -17,6 +17,7 @@ if [[ ${KUBE_NAMESPACE} == *prod ]]; then
     export MIN_REPLICAS="2"
     export MAX_REPLICAS="6"
     export KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
+    export UPTIME_PERIOD="Mon-Sun 05:00-23:00 Europe/London"
   if [[ "${KUBE_NAMESPACE}" == "wcs-prod" ]] ; then
       export DOMAIN_NAME="www.wcs.homeoffice.gov.uk"
       export INTERNAL_DOMAIN_NAME=''
@@ -30,6 +31,7 @@ else
     # non-production defaults:
     export MIN_REPLICAS="1"
     export MAX_REPLICAS="2"
+    export UPTIME_PERIOD="Mon-Fri 08:00-18:00 Europe/London"
     export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
     export KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
 

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: hocs-frontend
   labels:
     version: {{.VERSION}}
+  annotations:
+    downscaler/uptime: {{.UPTIME_PERIOD}}
 spec:
   replicas: {{.MIN_REPLICAS}}
   selector:


### PR DESCRIPTION
Presently, when the deployment changes the downscaler annotation 
(that was manually added up to present) gets removed. This causes 
pod to stay up indefinitely, which leads to increased costs and 
potential issues. This change enforced the uptime meta-data 
annotation that enforces this server stays up. This is specified 
differently depending on if we are in prod or notprod.