### PR TITLE
HOCS-3100 Add ACP tunnel IPs to demo ingress

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,8 @@ steps:
     VERSION: test
     ENVIRONMENT: wcs-dev
     KUBE_TOKEN: test
-    POISE_WHITELIST: "127.0.0.1/32"
+    POISE_IPS: "127.0.0.1/32"
+    ACPTUNNEL_IPS: "127.0.0.1/32"
   commands:
     - bash -x deploy.sh
   depends_on:
@@ -49,7 +50,8 @@ steps:
     VERSION: test
     ENVIRONMENT: cs-prod
     KUBE_TOKEN: test
-    POISE_WHITELIST: "127.0.0.1/32"
+    POISE_IPS: "127.0.0.1/32"
+    ACPTUNNEL_IPS: "127.0.0.1/32"
   commands:
     - bash -x deploy.sh
   depends_on:

--- a/kd/ingress-external.yaml
+++ b/kd/ingress-external.yaml
@@ -10,7 +10,7 @@ metadata:
     ingress.kubernetes.io/proxy-body-size: "52m"
     kubernetes.io/ingress.class: nginx-external
     ingress.kubernetes.io/proxy-buffer-size: 128k
-    ingress.kubernetes.io/whitelist-source-range: {{.IP_WHITELIST}}
+    ingress.kubernetes.io/whitelist-source-range: {{.ALLOWED_IPS}}
     ingress.kubernetes.io/server-snippets: |
       client_header_buffer_size     8k;
       large_client_header_buffers   4 128k;


### PR DESCRIPTION
This commit adds the IP addresses for the ACP tunnel VPN to the demo
environment's external ingress.

We don't add it to all notprod external ingresses to encourage users to
use the kube-platform VPN and the internal ingresses instead.

This commit also rewords some language to be more inclusive.