### PR TITLE
HOCS-3100 Don't check for IP range var presence

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,10 +6,6 @@ export KUBE_NAMESPACE=${ENVIRONMENT}
 export KUBE_TOKEN=${KUBE_TOKEN}
 export VERSION=${VERSION}
 
-export POISE_IPS=${POISE_IPS} # corporate network
-export ACPTUNNEL_IPS=${ACPTUNNEL_IPS} # digital VPN
-# https://docs.acp.homeoffice.gov.uk/support/ip-ranges
-
 export DOMAIN="cs"
 if [ "${KUBE_NAMESPACE%-*}" == "wcs" ]; then
     export DOMAIN="wcs"


### PR DESCRIPTION
Previously we explicitly checked for the presence of the ACPTUNNEL_IPS
and POISE_IPS environment variable at the start of the deploy.sh script.

This meant that you have to pass both env vars to every pipeline step in
Drone even though your step probably doesn't use them both.

This removes them, so they'll instead crash out the first time the
script tries to read them, which is still always going to be before
the script runs any kd commands.