### PR TITLE
HOCS-3079 Add env var indicating NOTPROD when not a production deployment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,7 @@ if [[ ${KUBE_NAMESPACE} == *prod ]]; then
     export ALLOWED_IPS=${POISE_IPS}
     export KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
     export UPTIME_PERIOD="Mon-Sun 05:00-23:00 Europe/London"
-    export KUBE_DISPLAY_ENV='PROD'
+    export KUBE_IS_NOTPROD=0
   if [[ "${KUBE_NAMESPACE}" == "wcs-prod" ]] ; then
       export DOMAIN_NAME="www.wcs.homeoffice.gov.uk"
       export INTERNAL_DOMAIN_NAME=''
@@ -40,7 +40,7 @@ else
 
     export DOMAIN_NAME="${SUBNAMESPACE}.${DOMAIN}-notprod.homeoffice.gov.uk"
     export INTERNAL_DOMAIN_NAME="${SUBNAMESPACE}.internal.${DOMAIN}-notprod.homeoffice.gov.uk"
-    export KUBE_DISPLAY_ENV='NOTPROD'
+    export KUBE_IS_NOTPROD=1
 
     # but remove the ingress for demo (preprod)
     # so at least one non-prod namespace has prod-like keycloak-proxy settings

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,6 +19,7 @@ if [[ ${KUBE_NAMESPACE} == *prod ]]; then
     export ALLOWED_IPS=${POISE_IPS}
     export KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
     export UPTIME_PERIOD="Mon-Sun 05:00-23:00 Europe/London"
+    export KUBE_DISPLAY_ENV='PROD'
   if [[ "${KUBE_NAMESPACE}" == "wcs-prod" ]] ; then
       export DOMAIN_NAME="www.wcs.homeoffice.gov.uk"
       export INTERNAL_DOMAIN_NAME=''

--- a/deploy.sh
+++ b/deploy.sh
@@ -39,6 +39,7 @@ else
 
     export DOMAIN_NAME="${SUBNAMESPACE}.${DOMAIN}-notprod.homeoffice.gov.uk"
     export INTERNAL_DOMAIN_NAME="${SUBNAMESPACE}.internal.${DOMAIN}-notprod.homeoffice.gov.uk"
+    export KUBE_DISPLAY_ENV='NOTPROD'
 
     # but remove the ingress for demo (preprod)
     # so at least one non-prod namespace has prod-like keycloak-proxy settings

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -320,6 +320,8 @@ spec:
             value: '300'
           - name: COUNTDOWN_FOR_SECONDS
             value: '60'
+          - name: RUNTIME_DISPLAY_ENV
+            value: {{.KUBE_DISPLAY_ENV}}
         resources:
           limits:
             cpu: 900m

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -320,8 +320,8 @@ spec:
             value: '300'
           - name: COUNTDOWN_FOR_SECONDS
             value: '60'
-          - name: RUNTIME_DISPLAY_ENV
-            value: {{.KUBE_DISPLAY_ENV}}
+          - name: IS_NOTPROD
+            value: {{.KUBE_IS_NOTPROD}}
         resources:
           limits:
             cpu: 900m


### PR DESCRIPTION
Add a new env var called RUNTIME_DISPLAY_ENV that contains NOTPROD if deployed into a non-prod environment.
https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-3079