### PR TITLE
Add quotes around version

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: hocs-frontend
   labels:
-    version: {{.VERSION}}
+    version: "{{.VERSION}}"
   annotations:
     downscaler/uptime: {{.UPTIME_PERIOD}}
 spec:
@@ -22,7 +22,7 @@ spec:
       labels:
         name: hocs-frontend
         role: hocs-frontend
-        version: {{.VERSION}}
+        version: "{{.VERSION}}"
     spec:
       containers:
       - name: certs


### PR DESCRIPTION
When deploying a 0.0.0 style version we got the error:
template:map[metadata:map[labels:map[version:0.5.5]] spec:map[]]]]":
cannot convert int64 to string

This commit adds quotes around the version number to make certain it's
being processed as a string, which might fix the problem; either way
it's better practice.