### PR TITLE
HOCS-3304 Quote int64 to coerce to str

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -321,7 +321,7 @@ spec:
           - name: COUNTDOWN_FOR_SECONDS
             value: '60'
           - name: IS_NOTPROD
-            value: {{.KUBE_IS_NOTPROD}}
+            value: '{{.KUBE_IS_NOTPROD}}'
         resources:
           limits:
             cpu: 900m


### PR DESCRIPTION
Kubernetes insists that environment variables are strings, but we're
passing 0 or 1 in, which is an integer. Surrounding the environment
variable value in quotes makes it a string, which is acceptable to
Kubernetes.