### PR TITLE
HOCS-3315: pass through stack trace visibility env

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -20,6 +20,8 @@ if [[ ${KUBE_NAMESPACE} == *prod ]]; then
     export KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
     export UPTIME_PERIOD="Mon-Sun 05:00-23:00 Europe/London"
     export KUBE_IS_NOTPROD=0
+    export SHOW_ERROR_STACKTRACE=0
+    
   if [[ "${KUBE_NAMESPACE}" == "wcs-prod" ]] ; then
       export DOMAIN_NAME="www.wcs.homeoffice.gov.uk"
       export INTERNAL_DOMAIN_NAME=''
@@ -41,6 +43,7 @@ else
     export DOMAIN_NAME="${SUBNAMESPACE}.${DOMAIN}-notprod.homeoffice.gov.uk"
     export INTERNAL_DOMAIN_NAME="${SUBNAMESPACE}.internal.${DOMAIN}-notprod.homeoffice.gov.uk"
     export KUBE_IS_NOTPROD=1
+    export SHOW_ERROR_STACKTRACE=1
 
     # but remove the ingress for demo (preprod)
     # so at least one non-prod namespace has prod-like keycloak-proxy settings
@@ -49,6 +52,7 @@ else
       # as kube-platform VPN doesn't get you into demo,
       # additionally allow acp-tunnel VPN IPs
       export ALLOWED_IPS="${POISE_IPS},${ACPTUNNEL_IPS}"
+      export SHOW_ERROR_STACKTRACE=0
     fi
 fi
 

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -322,6 +322,8 @@ spec:
             value: '60'
           - name: IS_NOTPROD
             value: '{{.KUBE_IS_NOTPROD}}'
+          - name: SHOW_STACKTRACE_ON_ERROR_PAGE
+            value: '{{.SHOW_ERROR_STACKTRACE}}'
         resources:
           limits:
             cpu: 900m


### PR DESCRIPTION
To enable the visibility of stacktraces in environments we currently 
rely on the `NODE_ENV` being anything but `production`. Toggling 
this has non-intentional consequences. A new environment variable 
is being passed through to enable the visibility of these stack traces 
through the frontend on error.